### PR TITLE
Explain slightly more general syntax for if-else expressions.

### DIFF
--- a/src/common-programming-concepts/control-flow/_mo/if-else.mo
+++ b/src/common-programming-concepts/control-flow/_mo/if-else.mo
@@ -1,0 +1,20 @@
+// IF ELSE
+
+let condition = true;
+
+let x = 
+// ANCHOR: a
+if (condition) 1 else 2;
+// ANCHOR_END: a
+
+// ANCHOR: b
+if (condition) { } else { };
+// ANCHOR_END: b
+
+// ANCHOR: c
+let result : Text = if (condition) {
+    "condition was true"
+} else {
+    "condition was false"
+};
+// ANCHOR_END: c

--- a/src/common-programming-concepts/control-flow/if-else-expression.md
+++ b/src/common-programming-concepts/control-flow/if-else-expression.md
@@ -1,26 +1,24 @@
 # If Else Expression
-The `if else` expression starts with an `if` expression (including two sub-expressions, a condition and its associated branch) followed by the `else` keyword and a third sub-expression:
+The `if else` expression starts with the `if` keyword followed by two sub-expressions (a condition and its associated branch) and ends with the `else` keyword and a third sub-expression:
 
 ```motoko
-if (condition) 1 else 2;
+{{#include _mo/if-else.mo:a}}
 ```
+
+The condition has to be of type `Bool`. When the condition evaluates to the value `true`, the second sub-expression `1` is returned. When the condition evaluates to the value `false`, the third sub-expression `2` is returned.
 
 When the branches are more complex expressions, they require curly braces:
 
 ```motoko
-if (condition) {if-branch} else {else-branch};
+{{#include _mo/if-else.mo:b}}
 ```
 
 Unlike `if` expressions that lack an `else`, when the first sub-expression of an `if else` evaluates to `false`, the entire `if else` expression evaluates as the third sub-expression, not the unit value `()`. 
 
-For example, this `if else` expression evaluates to a value of a certain type (`Text`), and we assign that value to a variable named `result`:
+For example, this `if else` expression evaluates to a value of a certain type `Text`, and we assign that value to a variable named `result`:
 
 ```motoko
-let result : Text = if (condition) {
-    "condition was true"
-} else {
-    "condition was false"
-}
+{{#include _mo/if-else.mo:c}}
 ```
 
-Generally, the second and third sub-expressions of the `if else` expression must evaluate to a value of the same type, as they do here (again, the common type is ``Text`).
+Generally, the second and third sub-expressions of the `if else` expression must evaluate to a value of the same type.

--- a/src/common-programming-concepts/control-flow/if-else-expression.md
+++ b/src/common-programming-concepts/control-flow/if-else-expression.md
@@ -1,13 +1,19 @@
 # If Else Expression
-The `if else` expression starts with an `if` expression followed by the `else` keyword and a third expression also enclosed in curly braces `{}`. When the first expression now evaluates to `false`, the third expression evaluates in stead of returning `()`. 
-
-It looks like this:
+The `if else` expression starts with an `if` expression (including two sub-expressions, a condition and its associated branch) followed by the `else` keyword and a third sub-expression:
 
 ```motoko
-if (condition) {} else {};
+if (condition) 1 else 2;
 ```
 
-To demonstrate that the *whole* `if else` expression evaluates to a value of a certain type, we assign that value to a variable named `result`:
+When the branches are more complex expressions, they require curly braces:
+
+```motoko
+if (condition) {if-branch} else {else-branch};
+```
+
+Unlike `if` expressions that lack an `else`, when the first sub-expression of an `if else` evaluates to `false`, the entire `if else` expression evaluates as the third sub-expression, not the unit value `()`. 
+
+For example, this `if else` expression evaluates to a value of a certain type (`Text`), and we assign that value to a variable named `result`:
 
 ```motoko
 let result : Text = if (condition) {
@@ -17,4 +23,4 @@ let result : Text = if (condition) {
 }
 ```
 
-The second and third expression of the `if else` expression (enclosed in curly braces `{}`) must evaluate to a value of the same type. In this case its the `Text` type and therefore the variable `result` has type `Text`. 
+Generally, the second and third sub-expressions of the `if else` expression must evaluate to a value of the same type, as they do here (again, the common type is ``Text`).


### PR DESCRIPTION
Nice draft!

I'm opening this PR after noticing that the `if else` syntax explanation claims that curly braces are required.  They are not, in fact.

The PR tries to do two things:

1. Explain that [this is legal Motoko](https://embed.smartcontracts.org/motoko/t/5NZBDjoFASgZLyKd2Jhv8cocV?lines=2):

```
if true 1 else 2;
```

2. Some other light copy-editing to clarify related points about the syntactic structure and what it means.