### PR TITLE
Fixed a Typo in classes.md ( 2.10.2 )

### DIFF
--- a/src/common-programming-concepts/objects-and-classes/classes.md
+++ b/src/common-programming-concepts/objects-and-classes/classes.md
@@ -59,7 +59,7 @@ Here's an example:
 Our `CryptoAccount` class takes the same two arguments as before, but now has only two members. One is the public mutable `balance` variable. The second is a _public function_. Because there are two public fields, the expected type of the object returned from this class is
 
     {
-        pay : () -> Nat;
+        pay : (Nat) -> ();
         balance : Nat;
     }
 


### PR DESCRIPTION
Fixed the incorrect object type for the CryptoAccount class. The previous type definition mistakenly had pay : () -> Nat, but the correct type is pay : (Nat) -> (), as the function accepts a Nat parameter and returns (). This fix ensures the documented type matches the actual class implementation, preventing confusion for developers.

![image](https://github.com/user-attachments/assets/af39aede-d1fd-4f67-9ae8-79440f18d23a)
